### PR TITLE
Fix solve() bug

### DIFF
--- a/R/EZbakRFractions.R
+++ b/R/EZbakRFractions.R
@@ -112,11 +112,11 @@ validate_EZbakRFractions <- function(obj){
 
   est_cols <- fraction_cols[!grepl("^fraction_", fraction_cols) &
                                        grepl("^logit_fraction_", fraction_cols) &
-                                       !(fraction_cols %in% c("sample", "n")) &
-                                       !grepl("^se_logit_fraction_", fraction_cols)]
+                                       !grepl("^se_logit_fraction_", fraction_cols) &
+                                       !(fraction_cols %in% c("sample", "n"))]
 
 
-  se_cols <- est_cols[grepl("^se_", est_cols)]
+  se_cols <- fraction_cols[grepl("^se_", fraction_cols)]
 
   expected_ests <- gsub("^se_", "", se_cols)
 

--- a/R/Fractions.R
+++ b/R/Fractions.R
@@ -772,12 +772,19 @@ EstimateFractions.EZbakRData <- function(obj, features = "all",
                                                    method = "L-BFGS-B",
                                                    hessian = TRUE))),
                                       list(I(list(par = -Inf,
-                                                  hessian = Inf)))),
+                                                  hessian = 1)))),
                          n = sum(n)) %>%
         dplyr::ungroup() %>%
         dplyr::mutate(
           !!col_name := purrr::map_dbl(fit, ~ .x$par[1]),
           !!uncertainty_col := purrr::map_dbl(fit, ~ sqrt(solve(.x$hessian)[1]))
+        ) %>%
+        dplyr::mutate(
+          !!uncertainty_col := ifelse(
+            !!dplyr::sym(col_name) == -Inf,
+            0,
+            !!dplyr::sym(uncertainty_col)
+          )
         ) %>%
         dplyr::select(-fit) %>%
         dplyr::mutate(!!natural_col_name := inv_logit(!!dplyr::sym(col_name))) %>%

--- a/R/Fractions.R
+++ b/R/Fractions.R
@@ -1808,12 +1808,19 @@ EstimateFractions.EZbakRArrowData <- function(obj, features = "all",
                                                        method = "L-BFGS-B",
                                                        hessian = TRUE))),
                                           list(I(list(par = -Inf,
-                                                      hessian = Inf)))),
+                                                      hessian = 1)))),
                              n = sum(n)) %>%
             dplyr::ungroup() %>%
             dplyr::mutate(
               !!col_name := purrr::map_dbl(fit, ~ .x$par[1]),
               !!uncertainty_col := purrr::map_dbl(fit, ~ sqrt(solve(.x$hessian)[1]))
+            ) %>%
+            dplyr::mutate(
+              !!uncertainty_col := ifelse(
+                !!dplyr::sym(col_name) == -Inf,
+                0,
+                !!dplyr::sym(uncertainty_col)
+              )
             ) %>%
             dplyr::select(-fit) %>%
             dplyr::mutate(!!natural_col_name := inv_logit(!!dplyr::sym(col_name))) %>%


### PR DESCRIPTION
Should address #9

R < 4.3 defines throws error when solve() is passed Inf. R >= 4.3 returns 0 (which makes more sense, 1/Inf = 0), which I was using to impute the uncertainty for -label sample fraction estimates. 