### PR TITLE
Fix bug in EZQC

### DIFF
--- a/R/Fractions.R
+++ b/R/Fractions.R
@@ -1297,6 +1297,15 @@ EstimateFractions.EZbakRArrowData <- function(obj, features = "all",
     unlist() %>%
     unname()
 
+  samples_with_no_label <- metadf %>%
+    dplyr::rowwise() %>%
+    dplyr::filter(all(dplyr::c_across(dplyr::all_of(tl_cols)) == 0)) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(sample) %>%
+    unlist() %>%
+    unname()
+
+
 
   ### Estimate fraction new for each feature in each sample
   message("Estimating fractions for each sample:")

--- a/R/QC.R
+++ b/R/QC.R
@@ -1062,6 +1062,9 @@ check_fl_dist <- function(obj,
 
 
       glist[[fc]][[samples[s]]] <- fractions %>%
+        dplyr::filter(
+          sample == samples[s]
+        ) %>%
         ggplot2::ggplot(aes(x = fraction)) +
         ggplot2::geom_density() +
         ggplot2::theme_classic() +

--- a/man/CorrectDropout.Rd
+++ b/man/CorrectDropout.Rd
@@ -14,7 +14,8 @@ CorrectDropout(
   repeatID = NULL,
   exactMatch = TRUE,
   read_cutoff = 25,
-  dropout_cutoff = 5
+  dropout_cutoff = 5,
+  ...
 )
 }
 \arguments{
@@ -68,6 +69,10 @@ the dropout model.}
 
 \item{dropout_cutoff}{Maximum ratio of -s4U:+s4U RPMs for a feature to be
 used to fit the dropout model (i.e., simple outlier filtering cutoff).}
+
+\item{...}{Parameters passed to internal \code{calculate_dropout()} function;
+namely \code{dropout_cutoff_min}, which sets the minimum dropout value used for
+fitting the dropout model.}
 }
 \value{
 An \code{EZbakRData} object with the specified "fractions" table replaced

--- a/man/VisualizeDropout.Rd
+++ b/man/VisualizeDropout.Rd
@@ -13,7 +13,9 @@ VisualizeDropout(
   fraction_design = NULL,
   repeatID = NULL,
   exactMatch = TRUE,
-  n_min = 50
+  n_min = 50,
+  dropout_cutoff = 5,
+  ...
 )
 }
 \arguments{
@@ -53,6 +55,10 @@ specify a subset of features by default. Set this to FALSE if you would like
 to specify a feature subset.}
 
 \item{n_min}{Minimum raw number of reads to make it to plot}
+
+\item{dropout_cutoff}{Maximum dropout value included in plot.}
+
+\item{...}{Parameters passed to internal \code{calculate_dropout()} function;}
 }
 \value{
 A list of \code{ggplot2} objects, one for each +label sample.


### PR DESCRIPTION
Fraction labeled distributions in EZQC output were the combination of all samples, rather than each sample individually.