### PR TITLE
Define type to prevent CRAN note after arrow 25.0.0 release

### DIFF
--- a/R/QC.R
+++ b/R/QC.R
@@ -493,7 +493,7 @@ check_plabeled <- function(obj,
 
 
   # Hack to deal with NOTEs
-  mutrate <- NULL
+  mutrate <- type <- NULL
 
 
   # Gotta fetch mutrates


### PR DESCRIPTION
We've just submitted a new version of Arrow to CRAN and when checking our reverse dependencies, they noticed that there is a NOTE from EZbakR:

```
Package: EZbakR
Check: R code for possible problems
New result: NOTE
  check_plabeled: no visible binding for global variable ‘type’
  Undefined global functions or variables:
    type
```

In the release we delete deprecated function `type()` which isn't used in EZbakR, but I think what's happened is that it existing in the Arrow namespace masked that NOTE from appearing sooner.

I've defined it as NULL here in the same format as the other workaround for the "no visible binding for global variable" issue for the `mutrate` variable, which should suppress the CRAN note.